### PR TITLE
Aggiunta Guida Docs Italia

### DIFF
--- a/projects_settings.yml
+++ b/projects_settings.yml
@@ -85,3 +85,9 @@ projects:
     website: https://www.spid.gov.it/
     documents:
       - spid-regole-tecniche
+  - 
+    name: Docs Italia
+    description: "Docs Italia è la piattaforma per i documenti tecnici e amministrativi della Pubblica Amministrazione"
+    website: https://docs.italia.it
+    documents:
+      - docs-italia-guide


### PR DESCRIPTION
Manca la Guida a Docs Italia fra i documenti presenti nella nuova piattaforma. 
Propongo di creare un progetto "Docs Italia" che contenga le eventuali guide (al momento solo questa...)