### PR TITLE
chore: add guida sviluppo software libero

### DIFF
--- a/projects_settings.yml
+++ b/projects_settings.yml
@@ -59,6 +59,7 @@ projects:
       - lg-acquisizione-e-riuso-software-per-pa-docs
       - gl-acquisition-and-reuse-software-for-pa-docs
       - policy-inserimento-catalogo-docs
+      - guida-sviluppo-gestione-software-libero
   -
     name: Ministro per l’innovazione tecnologica e la digitalizzazione
     short_name: MID


### PR DESCRIPTION
This PR:
* adds the `guida-sviluppo-software-libero` project to the Docs Italia builds.
@francescozaia please review, thanks!